### PR TITLE
Hide student consultations2

### DIFF
--- a/public/scripts/student_dashboard.js
+++ b/public/scripts/student_dashboard.js
@@ -97,6 +97,17 @@ if (showConsultation) {
   })
 }
 
+//if the user presses the "show consultation" button, display the default consulation.
+if (hideConsultation) {
+  console.log('Clicked hide consultation button')
+  hideConsultation.addEventListener('click', () => {
+  
+    // Remove all existing events from the calendar
+    calendar.getEvents().forEach((event) => event.remove())
+
+  })
+}
+
 async function fillLecturerField(){
   const lecturerDetails = await getLecturerDetails();
   for (let i = 0; i < Object.keys(lecturerDetails).length; i++) {

--- a/public/scripts/student_dashboard.js
+++ b/public/scripts/student_dashboard.js
@@ -97,9 +97,9 @@ if (showConsultation) {
   })
 }
 
-//if the user presses the "show consultation" button, display the default consulation.
+//if the user presses the "hide consultation on calendar" button, hide the consultations displayed on the calendar
 if (hideConsultation) {
-  console.log('Clicked hide consultation button')
+  console.log('Clicked hide consultation button') //log to the web console
   hideConsultation.addEventListener('click', () => {
   
     // Remove all existing events from the calendar

--- a/src/views/student_dashboard.ejs
+++ b/src/views/student_dashboard.ejs
@@ -34,7 +34,8 @@
     </div>
     <button id="bookButton" class="btn btn-primary" disabled>Book</button>
     <div id="consultationSlots" style="padding-top: 3rem;"></div>
-    <button type="button" id="showConsultation">Show Consultations</button>
+    <button type="button" id="showConsultation">Show Consultations on Calendar</button>
+    <button type="button" id="hideConsultation">Clear Consultations on Calendar</button>
     <div id="calendar"></div>
 
   <script src="/cdn/scripts/student_dashboard.js"></script>


### PR DESCRIPTION
##Description
I can remove the view of my consultations on the calendar
##Acceptance criteria
-On the student dashboard a button 'clear consultations on calendar appears'
-If consultations were made visible with 'show consultations on calendar button,' you can remove them using the clear button
-All consultations must disappear from the calendar
-But they are not deleted from the dataset

Note: end to end testing will come later on
##Story Points Expected:2

Closing https://github.com/witseie-elen4010/2023-group-lab-007/issues/54
