### PR TITLE
Students cannot exceed maximum consultations per day

### DIFF
--- a/public/scripts/student_dashboard.js
+++ b/public/scripts/student_dashboard.js
@@ -69,9 +69,10 @@ bookButton.addEventListener('click', async() => {
       date: String(selectedSlot),
       timeMinutes: parseInt(duration),
       maximumNumberOfStudents: parseInt(maxStudents),
-      status: String("disapproved"), //set default of disapproved, requires lecturer to accept consultation. 
+      status: String("approved"), //set default of disapproved, requires lecturer to accept consultation. 
       startTime: String(slotStart),
       endTime: String(slotEnd),
+      title: String("test"),
    }
    console.log(details)
    createConsultation(details)
@@ -676,6 +677,7 @@ function createSubperiodDropdown(possibleSlots, duration) {
   
   // Create the subperiod dropdown
   const subperiodDropdown = document.createElement('select')
+  subperiodDropdown.classList.add('form-control');
   subperiodDropdown.id = 'subperiodDropdown'
   const defaultOption = document.createElement('option')
   defaultOption.text = 'Select a consultation slot'
@@ -809,26 +811,26 @@ function getPossibleSlots(totalStart, totalEnd, bookedSlots, duration) {
       }
   }
 
-  return possibleSlots;
+  return possibleSlots
 }
 
 // Existing duration adjustment code here...
 
 slotDropdownMenu.addEventListener('change', function() {
-  var selectedOption = this.value;
+  var selectedOption = this.value
   if (selectedOption !== '') { 
-      document.getElementById('durationSelector').style.display = 'block'; // Show the duration selector
+      document.getElementById('durationSelector').style.display = 'block' // Show the duration selector
       document.getElementById('duration').value = '15'
       document.getElementById('duration').dataset.maxDuration = this.options[this.selectedIndex].dataset.maxDuration
   } else {
-      document.getElementById('durationSelector').style.display = 'none'; // Hide the duration selector
+      document.getElementById('durationSelector').style.display = 'none' // Hide the duration selector
   }
-});
+})
 
 
 document.getElementById('minus').addEventListener('click', function() {
-  var durationInput = document.getElementById('duration');
-  var currentValue = parseInt(durationInput.value, 10);
+  var durationInput = document.getElementById('duration')
+  var currentValue = parseInt(durationInput.value, 10)
   if(currentValue>0){
 
   }
@@ -836,16 +838,16 @@ document.getElementById('minus').addEventListener('click', function() {
     currentValue=15
   }
   if (currentValue > 15) { // Prevent the value from dropping below 15
-      durationInput.value = currentValue - 15;
+      durationInput.value = currentValue - 15
   }
   showAvailableConsultations()
-});
+})
 
 document.getElementById('plus').addEventListener('click', function() {
-  var durationInput = document.getElementById('duration');
+  var durationInput = document.getElementById('duration')
   const maxDuration = durationInput.dataset.maxDuration
   console.log(maxDuration)
-  var currentValue = parseInt(durationInput.value, 10);
+  var currentValue = parseInt(durationInput.value, 10)
   if(currentValue>0){
 
   }
@@ -856,7 +858,7 @@ document.getElementById('plus').addEventListener('click', function() {
   durationInput.value = currentValue + 15
   }
   showAvailableConsultations()
-});
+})
 
 async function showAvailableConsultations(){
   selectedTeacher = dropdownMenu.value

--- a/public/scripts/student_dashboard.js
+++ b/public/scripts/student_dashboard.js
@@ -57,7 +57,7 @@ bookButton.addEventListener('click', async() => {
      }
      const slotStart = selectedPeriod.options[selectedPeriod.selectedIndex].dataset.start
      const slotEnd = selectedPeriod.options[selectedPeriod.selectedIndex].dataset.end
-     const duration = selectedPeriod.value
+     const duration = document.getElementById("duration").value
      getAllConsultations()
   .then(detailsArray => {
     const consultationIds = detailsArray.map(detail => detail.consultationId)
@@ -145,6 +145,7 @@ dropdownMenu.addEventListener('change', async (e) => {
     existingConsultationsMenu.remove(1)
   }
   removeSubperiodDropdown()
+  existingConsultationsMenu.removeAttribute('disabled') // enable existing consultations
   if (selectedTeacher) {
     // I am assuming that teacher object has an id field that represents the lecturerId
     const slots = await searchConsultations(selectedTeacher)
@@ -344,7 +345,9 @@ function getDateString(date) {
 
 function checkButtonStatus() {
   const teacherSelected = dropdownMenu.value !== ""
-  const slotSelected = slotDropdownMenu.value !== ""
+  const subPeriodDropdown = document.getElementById("subPeriodDropdown");
+  const slotSelected = (subPeriodDropdown !== null && subPeriodDropdown.value !== "") ? true : false;
+
   const existingConsultationSelected = existingConsultationsMenu.value !== ""
 
   if (teacherSelected && (slotSelected||existingConsultationSelected)) {
@@ -526,6 +529,7 @@ dropdownMenu.addEventListener('change', async (e) => {
       option.dataset.endTime = consultation.endTime
       option.dataset.numberOfStudents = consultation.maximumNumberOfStudents
       existingConsultationsMenu.add(option)
+      existingConsultationsMenu.add(option)
     }
   }
 })
@@ -698,6 +702,9 @@ function createSubperiodDropdown(possibleSlots, duration) {
 
   // Add the dropdown to the DOM
   dropdownContainer.appendChild(subperiodDropdown)
+  subperiodDropdown.addEventListener('change', function() {
+    bookButton.removeAttribute('disabled');
+  });
 }
 
 // Function to remove the subperiod dropdown from the DOM
@@ -745,7 +752,7 @@ slotDropdownMenu.addEventListener('change',async function() {
   console.log(bookedSlots)
   duration = document.getElementById("duration").value
   possibleSlots = getPossibleSlots(startTime, endTime, bookedSlots, duration)
-  createSubperiodDropdown(possibleSlots, 30)
+  createSubperiodDropdown(possibleSlots, duration)
 
   } else { 
     existingConsultationsMenu.removeAttribute('disabled') // enable existing consultations
@@ -829,6 +836,7 @@ slotDropdownMenu.addEventListener('change', function() {
 
 
 document.getElementById('minus').addEventListener('click', function() {
+  removeSubperiodDropdown()
   var durationInput = document.getElementById('duration')
   var currentValue = parseInt(durationInput.value, 10)
   if(currentValue>0){
@@ -844,6 +852,7 @@ document.getElementById('minus').addEventListener('click', function() {
 })
 
 document.getElementById('plus').addEventListener('click', function() {
+  removeSubperiodDropdown()
   var durationInput = document.getElementById('duration')
   const maxDuration = durationInput.dataset.maxDuration
   console.log(maxDuration)
@@ -881,4 +890,6 @@ async function showAvailableConsultations(){
   duration = document.getElementById("duration").value
   possibleSlots = getPossibleSlots(startTime, endTime, bookedSlots, duration)
   createSubperiodDropdown(possibleSlots, 30)
+  
+
 }

--- a/src/schemas/tablesSchemas.js
+++ b/src/schemas/tablesSchemas.js
@@ -8,6 +8,7 @@ const consultationDetailsScheme = {
   status: String,
   startTime: String,
   endTime: String,
+  title: String,
 };
 
 const consultationPeriodsScheme = {

--- a/src/views/student_dashboard.ejs
+++ b/src/views/student_dashboard.ejs
@@ -43,7 +43,14 @@
       <label for="slotList">Select Consultation Slot</label>
       <select class="form-control" id="slotList"></select>
     </div>
+    <div id="durationSelector" style="display: none;">
+      <label for="duration">Duration (minutes): </label>
+      <button type="button" id="minus">-</button>
+      <input type="text" id="duration" value="" readonly>
+      <button type="button" id="plus">+</button>
+  </div>
     <div class="form-group" style="margin-bottom: 2rem;" id="dropdownContainer">
+      
       <!-- The subperiod dropdown will be appended here -->
    </div>   
     <button id="bookButton" class="btn btn-primary" disabled>Book</button>

--- a/src/views/student_dashboard.ejs
+++ b/src/views/student_dashboard.ejs
@@ -45,9 +45,9 @@
     </div>
     <div id="durationSelector" style="display: none;">
       <label for="duration">Duration (minutes): </label>
-      <button type="button" id="minus">-</button>
-      <input type="text" id="duration" value="" readonly>
-      <button type="button" id="plus">+</button>
+      <button type="button" id="minus" class="btn btn-primary">-</button>
+      <input type="text" id="duration" value="" readonly style="padding: 0;">
+      <button type="button" id="plus" class="btn btn-primary">+</button>
   </div>
     <div class="form-group" style="margin-bottom: 2rem;" id="dropdownContainer">
       


### PR DESCRIPTION
Story ref: [As a student (organiser), cannot exceed maximum consultations per day#84](https://github.com/witseie-elen4010/2023-group-lab-007/issues/84)
 ## Description
- After selecting a lecturer's period on a specific day, specify a time between 15 minutes and the maximum duration allowed, as restricted by the maximum number of consultations per day. Thereafter, a selection of all possible slots fulfilling all of the acceptance criteria is shown and can be selected to book a consultation. 

## Acceptance criteria

### Consultation Booking
- The organizer is able to specify the length of the consultation
- The organizer is able to see all the possible consultations with the lecturer in the period selected with the desired duration
- The organizer should not be able to book an overlapping consultation 
- The user cannot exceed the Maximum number of consultations per day that the lecturer specified
- The user cannot select a length longer than the maximum allowed length
- Restrict button functionality to the current possible user actions
- Hide fields when they are not relevant to the user
## Additional features implemented but not limited to user stories
- Consultations that have been disapproved are not shown to the user. 
## Expected Points
4